### PR TITLE
include wasm for snap

### DIFF
--- a/.github/workflows/publish-ghpages.yml
+++ b/.github/workflows/publish-ghpages.yml
@@ -10,15 +10,13 @@ permissions:
 jobs:
   wasi_job:
     runs-on: ubuntu-latest
-    name: WASI attempt 
+    name: WASI module
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
-      with:
-        go-version: '>=1.18.0'
 
     - name: WASI flite step
       run: |
+        sudo apt-get -y install clang libasound2-dev
         wget -q https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk_16.0_amd64.deb
         sudo dpkg -i wasi-sdk_16.0_amd64.deb
         git clone --depth=1 https://github.com/shrmpy/flite.git
@@ -26,7 +24,7 @@ jobs:
         cp patch/copy_buffer_main.c flite/main/
         cp patch/main.Makefile flite/main/Makefile
         cd flite
-        ./configure --host=wasm32-wasi CC=/opt/wasi-sdk/bin/clang AR=/opt/wasi-sdk/bin/llvm-ar RANLIB=/opt/wasi-sdk/bin/llvm-ranlib
+        ./configure --host=wasm32-wasi CC=clang AR=/opt/wasi-sdk/bin/llvm-ar RANLIB=/opt/wasi-sdk/bin/llvm-ranlib
         make
 
     - name: WASI artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ google-services.json
 *.aar
 *.jar
 mobile/android/app/release/
-*.wasm
 
 # IntelliJ related
 *.iml

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cd fgj2022
 # make snap 
 snapcraft
 # local install
-sudo snap install fgj2022_0.0.4_arm64.snap --dangerous
+sudo snap install fgj2022_0.0.5_arm64.snap --dangerous
 # start program
 fgj2022
 ```

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,38 +27,12 @@ layout:
 
 apps:
   fgj2022:
-    command: $SNAP/bin/fgj2022
+    command: bin/fgj2022
     command-chain: ["bin/desktop-launch"]
     plugs: [network,x11,unity7,opengl,alsa,audio-playback,pulseaudio]
 
 parts:
-  locsrc:
-    source: .
-    plugin: dump
-  wasi-sdk:
-    after: [chk-part]
-    source: https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk_16.0_amd64.deb
-    source-type: deb
-    plugin: dump
-  wasm-flite:
-    after: [wasi-sdk]
-    source: https://github.com/shrmpy/flite.git
-    source-depth: 1
-    plugin: autotools
-    build-environment:
-    - CC: "clang"
-    autotools-configure-parameters: [ --host=wasm32-wasi ]
-    override-pull: |
-        snapcraftctl pull
-        cp $SNAPCRAFT_PART_SRC/../locsrc/patch/cst_wave_io.c flite/src/speech/
-        cp $SNAPCRAFT_PART_SRC/../locsrc/patch/copy_buffer_main.c flite/main/
-        cp $SNAPCRAFT_PART_SRC/../locsrc/patch/main.Makefile flite/main/Makefile
-    build-packages: 
-    - libasound2-dev
-    - clang
-
   g-build:
-    after: [wasm-flite]
     plugin: go
     source: .
     override-pull: |
@@ -66,7 +40,6 @@ parts:
         version="$(git describe --tags --long)"
         snapcraftctl set-version "$version"
         snapcraftctl set-grade stable
-        cp $SNAPCRAFT_PART_BUILD/../wasm-flite/bin/copy_buffer dist/flite.wasm
     build-packages: 
     - git
     - libc6-dev


### PR DESCRIPTION
flite.wasm file is build by gh-workflow and theoritically can also be done in ci for snap, but postponing troubleshooting it and resorting to keeping the wasm in src repo.